### PR TITLE
disabled ability to equip the recording tool

### DIFF
--- a/NomaiVROnlinePatches/ChatPatches.cs
+++ b/NomaiVROnlinePatches/ChatPatches.cs
@@ -28,10 +28,11 @@ namespace NomaiVROnlinePatches
             UpdateOpenChat = AccessTools.MethodDelegate<Action>(AccessTools.DeclaredMethod(chatHandlerType, "UpdateOpenChat"), __instance);
             hiddenInputField = (new UnityEngine.GameObject("VRChatField")).AddComponent<InputField>();
 
+            
             enterChatPrompt = new ScreenPrompt(InputLibrary.toolActionSecondary, InputLibrary.interact, "<CMD1>+<CMD2> Start chatting", ScreenPrompt.MultiCommandType.CUSTOM_BOTH);
             Locator.GetPromptManager().RemoveScreenPrompt((ScreenPrompt)AccessTools.Field(chatHandlerType, "enterChatPrompt").GetValue(__instance));
             AccessTools.Field(chatHandlerType, "enterChatPrompt").SetValue(__instance, enterChatPrompt);
-            Locator.GetPromptManager().AddScreenPrompt(enterChatPrompt, PromptPosition.UpperRight, true);
+            //Locator.GetPromptManager().AddScreenPrompt(enterChatPrompt, PromptPosition.UpperRight, true);
         }
 
         public static void OnSteamVRKeyboaredClosed(VREvent_t evt)

--- a/NomaiVROnlinePatches/MessagePatches.cs
+++ b/NomaiVROnlinePatches/MessagePatches.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using HarmonyLib;
+
+namespace NomaiVROnlinePatches
+{
+    public class MessagePatches
+    {
+        private const string k_MessageHandlerQualifiedTypeName = "OuterWildsOnline.MessageHandler, OuterWildsMMO";
+
+        //disables ability to equip recording tool
+        [HarmonyPatch(k_MessageHandlerQualifiedTypeName, "StartPlacing")]
+        [HarmonyPrefix]
+        public static bool RecordingTool_StartPlacing(Object __instance)
+        {
+            return false;
+        }
+        
+        //disables button prompt
+        [HarmonyPatch(k_MessageHandlerQualifiedTypeName, "OnSuitUp")]
+        [HarmonyPrefix]
+        public static bool RecordingTool_OnSuitUp(Object __instance)
+        {
+            return false;
+        }
+    }
+}

--- a/NomaiVROnlinePatches/NomaiVROnlinePatches.cs
+++ b/NomaiVROnlinePatches/NomaiVROnlinePatches.cs
@@ -22,6 +22,7 @@ namespace NomaiVROnlinePatches
             }
 
             Harmony.CreateAndPatchAll(typeof(ChatPatches));
+            Harmony.CreateAndPatchAll(typeof(MessagePatches));
         }
 
         private bool CheckVersion()


### PR DESCRIPTION
I disabled the ability to equip the recording tool because it caused these issues:
-The tool automatically equips when you suit up
-The the prompts that appear when you equip the tool (start writing and cancel) do not disappear when the tool is unequipped
-Once the tool is equipped, the game cannot be paused even after unequipping the tool